### PR TITLE
Add a "mapping" section.

### DIFF
--- a/draft-law-moq-warpmedia.md
+++ b/draft-law-moq-warpmedia.md
@@ -81,8 +81,8 @@ This document uses the conventions detailed in Section 1.3 of {{!RFC9000}} when 
 # Mapping
 Warp is split into two components:
 
-* A generic transport protocol ({{MoQTransport}})
-* A media transport protocol layered on top.
+* A generic transport {{MoQTransport}}
+* A media layer on top.
 
 This section specifies how media is layered on top of the generic transport.
 
@@ -91,7 +91,7 @@ A media broadcast is broken into media tracks.
 Each track consists of an encoded bitstream, typically compressed using a codec, appended while new media is generated.
 Examples include audio tracks, video tracks, caption tracks, and metadata tracks.
 
-Each media track MUST be sent over a dedicated {{MoqTransport}} track.
+Each media track MUST be sent over a dedicated transport track {{MoQTransport}}.
 
 ## Groups
 A media track is further fragmented into media groups that can be delivered and decoded independently.
@@ -104,16 +104,16 @@ The application is responsible for the trade-off between overhead and when media
 A media group MAY reference samples from other groups, although it is NOT RECOMMENDED as delivery is not guaranteed.
 However this is necessary when decoding audio, as reinitializing the decoder for each group will cause noticable artifacts.
 
-Each media group MUST be sent over a dedicated {{MoqTransport}} group.
+Each media group MUST be sent over a dedicated transport group {{MoQTransport}}.
 
 ## Objects
 A media group is futher fragmented into media objects, the smallest transport unit.
 Media may be fragmented into smaller parts based on the encoding, but that is opaque to the transport.
 
-To recap, an {{MoqTransport}} object consists of an ordered bitstream.
+To recap, an object consists of an ordered bitstream {{MoQTransport}}.
 The transport will ensure that the contents of object are streamed in order and without gaps.
 Howwever, an object MAY be starved or reset (with an error code) for any reason, typically in response to congestion.
-These properties the same as provided by a QUIC stream.
+These are properties are similar to a QUIC stream {{QUIC}}.
 
 The encoder is responsible for determining what media to encode in each object.
 The simplest configuration is to deliver each group as a single object, consisting of all samples/frames in dependency order.
@@ -123,6 +123,7 @@ For example, an object per video frame, or an object per X audio samples.
 Each object MUST be prioritized according to its dependencies, so that the transport will attempt deliver in a decodable order.
 
 The encoder and decoder SHOULD process each object as a stream (instead of buffering) to minimize latency.
+
 
 # Packaging
 Each codec bitstream MUST be packaged in to a sequence of Objects within a separate track.


### PR DESCRIPTION
Indicates the high-level relationship between media and the generic transport. This section will be true regardless of the specific encoding used.

@suhasHere @fluffy @huitema @vasilvv @afrind