### PR TITLE
Adding isComplete and rules for terminating a broadcast

### DIFF
--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -298,7 +298,8 @@ Location: R    Required: Optional    JSON Type: Boolean
 
 Issued once a previously live broadcast is complete. This is a commitment that all
 tracks are complete, no new tracks will be added and no new content will be
-published. This field MUST NOT be included if it is FALSE.
+published. This field MUST NOT be included if it is FALSE. This field MUST NOT be
+removed from a catalog once it has been added.
 
 ### Tracks {#tracks}
 Location: R    Required: Yes    JSON Type: Array
@@ -972,8 +973,8 @@ A timeline track MUST carry a 'type' identifier in the Catalog with a value of
 contains an array of all track names to which the timeline track applies.
 
 ## Timeline track updating.
-The publisher MUST publish a complete timeline in the first MOQT Object of each
-MOQT Group of a timeline track. The publisher MAY publish incremental updates
+The publisher MUST publish an indepdendent timeline in the first MOQT Object of
+each MOQT Group of a timeline track. The publisher MAY publish incremental updates
 in the second and subsequent Objects within each GROUP. Incremental updates
 only contain timeline events since the last timeline Object. Group duration
 SHOULD not exceed 30 seconds inside a timeline track.
@@ -986,13 +987,17 @@ track objects.
 
 ## Ending a live broadcast
 After publishing a catalog and defining tracks carrying live content, an original
-publisher can deliver a deterministic signal to all subscribers that it is complete
-by taking the following steps:
+publisher can deliver a deterministic signal to all subscribers that the broadcast
+is complete by taking the following steps:
 
 * Send a SUBSCRIBE_DONE (See MOQT Sect 8.1.2) message for all active tracks using
   status code 0x2	Track Ended.
-* Publish a catalog update, either absolute or as delta update, which signals
-  isComplete as TRUE.
+* If the live stream is being converted instantly to a VOD asset, then publish an
+  independent (non-delta) catalog update which, for each tracks, sets isLive {{islive}}
+  to FALSE and adds a track duration {{trackduration}} field.
+* If the live stream is being terminated permanently without conversion to VOD, then
+  publish an independent catalog update which signals isComplete {{iscomplete}} as
+  TRUE and which contains an empty Track {{tracks}} field.
 
 # Security Considerations
 

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -998,7 +998,7 @@ is complete by taking the following steps:
   to FALSE and adds a track duration {{trackduration}} field.
 * If the live stream is being terminated permanently without conversion to VOD, then
   publish an independent catalog update which signals isComplete {{iscomplete}} as
-  TRUE and which contains an empty Track {{tracks}} field.
+  TRUE and which contains an empty Tracks {{tracks}} field.
 
 # Security Considerations
 

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -212,6 +212,7 @@ Table 1 provides an overview of all fields defined by this document.
 | Remove tracks           | removeTracks           | {{removetracks}}          |
 | Clone tracks            | cloneTracks            | {{clonetracks}}           |
 | Generated at            | generatedAt            | {{generatedat}}           |
+| Is Complete             | isComplete             | {{iscomplete}}            |
 | Tracks                  | tracks                 | {{tracks}}                |
 | Track namespace         | namespace              | {{tracknamespace}}        |
 | Track name              | name                   | {{trackname}}             |
@@ -291,6 +292,13 @@ Location: R    Required: Optional    JSON Type: Number
 The wallclock time at which this catalog instance was generated, expressed as the
 number of milliseconds that have elapsed since January 1, 1970 (midnight UTC/GMT).
 This field SHOULD NOT be included if the isLive field is false.
+
+### Is Complete {#iscomplete}
+Location: R    Required: Optional    JSON Type: Boolean
+
+Issued once a previously live broadcast is complete. This is a commitment that all
+tracks are complete, no new tracks will be added and no new content will be
+published. This field MUST NOT be included if it is FALSE.
 
 ### Tracks {#tracks}
 Location: R    Required: Yes    JSON Type: Array
@@ -889,6 +897,20 @@ and video tracks.
 
 ~~~
 
+### Terminating a live broadcast
+
+This example shows catalog for a media producer terminating a previously
+live broadcast containing a video and an audio track. 
+
+~~~json
+{
+  "version": 1,
+  "generatedAt": 1746104606044,
+  "isComplete": TRUE
+}
+
+~~~
+
 
 # Media transmission
 The MOQT Groups and MOQT Objects need to be mapped to MOQT Streams. Irrespective
@@ -962,10 +984,14 @@ SHOULD not exceed 30 seconds inside a timeline track.
 A WARP publisher MUST publish a catalog track object before publishing any media
 track objects.
 
-At the completion of a session, a publisher MUST publish a catalog update that
-removes all currently active tracks.  This action SHOULD be interpreted by
-receivers to mean that the publish session is complete.
-
+## Ending a live broadcast
+After publishing a catalog and defining tracks carrying live content, an original
+publisher can deliver a deterministic signal to all subscribers that it is complete
+by taking the following steps:
+* Send a SUBSCRIBE_DONE (See MOQT Sect 8.1.2) message for all active tracks using
+  status code 0x2	Track Ended.
+* Publish a catalog update, either absolute or as delta update, which signals
+  isComplete as TRUE.
 
 # Security Considerations
 

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -900,7 +900,7 @@ and video tracks.
 ### Terminating a live broadcast
 
 This example shows catalog for a media producer terminating a previously
-live broadcast containing a video and an audio track. 
+live broadcast containing a video and an audio track.
 
 ~~~json
 {

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -988,6 +988,7 @@ track objects.
 After publishing a catalog and defining tracks carrying live content, an original
 publisher can deliver a deterministic signal to all subscribers that it is complete
 by taking the following steps:
+
 * Send a SUBSCRIBE_DONE (See MOQT Sect 8.1.2) message for all active tracks using
   status code 0x2	Track Ended.
 * Publish a catalog update, either absolute or as delta update, which signals

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -907,7 +907,8 @@ live broadcast containing a video and an audio track.
 {
   "version": 1,
   "generatedAt": 1746104606044,
-  "isComplete": TRUE
+  "isComplete": TRUE,
+  "tracks": []
 }
 
 ~~~

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -994,7 +994,7 @@ is complete by taking the following steps:
 * Send a SUBSCRIBE_DONE (See MOQT Sect 8.1.2) message for all active tracks using
   status code 0x2	Track Ended.
 * If the live stream is being converted instantly to a VOD asset, then publish an
-  independent (non-delta) catalog update which, for each tracks, sets isLive {{islive}}
+  independent (non-delta) catalog update which, for each track, sets isLive {{islive}}
   to FALSE and adds a track duration {{trackduration}} field.
 * If the live stream is being terminated permanently without conversion to VOD, then
   publish an independent catalog update which signals isComplete {{iscomplete}} as


### PR DESCRIPTION
This PR adds a definition for the isComplete catalog field, adds a new catalog example and adds a workflow section instructing publishers how to cleanly end a broadcast.

Fixes #59 