### PR TITLE
Adding Event timeline track

### DIFF
--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -957,11 +957,11 @@ in Group IDs using the MOQT Prior Group ID Gap Extension header.
 
 # Media Timeline track {#mediatimelinetrack}
 The media timeline track provides data about the previously published groups and their
-relationship to wallclock time and media time. Media timeline tracks allow players to seek to
-precise points behind the live head in a live broadcast, or for random access in a
-VOD asset. The optional metadata can describe a characteristic of any record in the media 
-timeline. Media timeline tracks are optional. Multiple media timeline tracks can exist inside a
-catalog.
+relationship to wallclock time and media time. Media timeline tracks allow players to
+seek to precise points behind the live head in a live broadcast, or for random access
+in a VOD asset. The optional metadata can describe a characteristic of any record in
+the media timeline. Media timeline tracks are optional. Multiple media timeline tracks
+can exist inside a catalog.
 
 ## Media Timeline track payload {#mediatimelinepayload}
 The payload of a media timeline track is a UTF-8 encoded CSV text file. This

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1033,7 +1033,7 @@ An event timeline track MUST carry a 'type' identifier in the Catalog with a val
 of "eventtimeline". An event timeline track MUST carry a 'depends' attribute which
 contains an array of all track names to which the event timeline track applies.
 
-## Event Timeline track updating.
+## Event Timeline track updating
 The publisher MUST publish an indepdendent event timeline in the first MOQT Object
 of each MOQT Group of an event timeline track. The publisher MAY publish incremental
 updates in the second and subsequent Objects within each Group. Incremental updates

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1000,7 +1000,7 @@ contains an array of all track names to which the media timeline track applies.
 ## Media Timeline track updating
 The publisher MUST publish an indepdendent media timeline in the first MOQT Object
 of each MOQT Group of a media timeline track. The publisher MAY publish incremental
-updates in the second and subsequent Objects within each GROUP. Incremental updates
+updates in the second and subsequent Objects within each Group. Incremental updates
 only contain media timeline records since the last media timeline Object.
 
 # Event Timeline track {#eventtimelinetrack}

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1009,7 +1009,7 @@ the broadcast. Use-case examples include live sports score data, GPS coordinates
 cars, or active speaker notifications in web conferences.
 
 To allow the client to bind this event metadata with the broadcast content described by
-the media timeline track, each event record MUST contain a reference to either GroupID,
+the media timeline track, each event record MUST contain a reference to GroupID,
 Media PTS or wallclock time.
 
 Event timeline tracks are optional. Multiple event timeline tracks can exist inside a

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1020,11 +1020,10 @@ An event timeline track is a JSON {{JSON}} document. It contains an array of rec
 Each record consists of a JSON Object containing the following required fields:
 
 * A timeline reference, which MUST be either 't' for wallclock time, 'g' for Group ID or
-  'm' for Media PTS. Typically only one timeline reference is included in each record,
-  although multiple timeline entries may exist within a record, as long as they
-  express temporal consistency. Event timelines SHOULD use the same timeline indexing for
-  each record. The definitions for wallclock time, GroupID and Media PTS are identical to
-  those defined for media timeline payload {{mediatimelinepayload}}.
+  'm' for Media PTS. Only one of these index values may be used within a record. Event
+  timelines SHOULD use the same timeline index type for each record. The definitions for
+  wallclock time, GroupID and Media PTS are identical to those defined for media timeline
+  payload {{mediatimelinepayload}}.
 * A 'type' field, which is a String defining the type of data contained within the data
   field. Types are defined by the application provider.
 * A 'data' Object, whose structure is defined by the 'type' value.

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -957,10 +957,10 @@ in Group IDs using the MOQT Prior Group ID Gap Extension header.
 
 # Media Timeline track {#mediatimelinetrack}
 The media timeline track provides data about the previously published groups and their
-relationship to wallclock time and media time. Timeline tracks allow players to seek to
+relationship to wallclock time and media time. Media timeline tracks allow players to seek to
 precise points behind the live head in a live broadcast, or for random access in a
-VOD asset. The optional metadata can describe a characteristic of any record in the
-timeline. Timeline tracks are optional. Multiple timeline tracks can exist inside a
+VOD asset. The optional metadata can describe a characteristic of any record in the media 
+timeline. Media timeline tracks are optional. Multiple media timeline tracks can exist inside a
 catalog.
 
 ## Media Timeline track payload {#mediatimelinepayload}

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -997,7 +997,7 @@ A media timeline track MUST carry a 'type' identifier in the Catalog with a valu
 of "mediatimeline". A media timeline track MUST carry a 'depends' attribute which
 contains an array of all track names to which the media timeline track applies.
 
-## Media Timeline track updating.
+## Media Timeline track updating
 The publisher MUST publish an indepdendent media timeline in the first MOQT Object
 of each MOQT Group of a media timeline track. The publisher MAY publish incremental
 updates in the second and subsequent Objects within each GROUP. Incremental updates

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1036,7 +1036,7 @@ contains an array of all track names to which the event timeline track applies.
 ## Event Timeline track updating.
 The publisher MUST publish an indepdendent event timeline in the first MOQT Object
 of each MOQT Group of an event timeline track. The publisher MAY publish incremental
-updates in the second and subsequent Objects within each GROUP. Incremental updates
+updates in the second and subsequent Objects within each Group. Incremental updates
 only contain event timeline records since the last event timeline Object.
 
 ## Example event timeline track


### PR DESCRIPTION
This PR renames the timeline track to "Media timeline", changes its definition so that it refers only to the media published by the original publisher and then adds a new Event timeline track defintion to hold externally generated timeline data. 

Fixes #66 