### PR TITLE
Undo commit ae4b7c4

### DIFF
--- a/draft-ietf-moq-msf.md
+++ b/draft-ietf-moq-msf.md
@@ -356,10 +356,9 @@ The following operation types are defined:
 
 * "clone" - Clone new tracks from previously declared tracks. The value of
   the "tracks" field is an Array of track objects {{trackobject}}. Each track
-  object MUST include a Parent Name {{parentname}} field and MAY include a
-  Parent namespace {{parentnamespace}} field. The cloned track inherits all
-  attributes from the parent except the Track Name which MUST be new.
-  Attributes redefined in the track object override inherited values.
+  object MUST include a Parent Name {{parentname}} field. The cloned track
+  inherits all attributes from the parent except the Track Name which MUST
+  be new. Attributes redefined in the track object override inherited values.
 
 ## Track Object Fields
 
@@ -394,7 +393,6 @@ Table 2 lists the fields defined within each track object.
 | Display height          | displayHeight          | {{displayheight}}         |
 | Language                | lang                   | {{language}}              |
 | Parent name             | parentName             | {{parentname}}            |
-| Parent namespace        | parentNameSpace        | {{parentnamespace}}       |
 | Track duration          | trackDuration          | {{trackduration}}         |
 | Authorization Info      | authInfo               | {{authinfo}}              |
 | Accessibility           | accessibility          | {{accessibility}}         |
@@ -636,13 +634,6 @@ Required: Optional    JSON Type: String    Location: Track Object
 
 A string defining the parent track name {{trackname}} to be cloned. This field
 MUST only be included inside a clone operation in a delta update {{deltaupdate}}.
-
-### Parent namespace {#parentnamespace}
-Required: Optional    JSON Type: String    Location: Track Object
-
-A string defining the parent track namespace {{tracknamespace}} to be cloned. This field
-MUST only be included inside a clone operation in a delta update {{deltaupdate}}. If this
-field is missing from a clone operation, then the namespace of the catalog is assumed.
 
 ### Track duration {#trackduration}
 Required: Optional    JSON Type: Number    Location: Track Object
@@ -1140,7 +1131,6 @@ the other is cloned from a previous track.
       "tracks": [
         {
           "parentName": "video-1080",
-          "parentNameSpace": "example.com/custom",
           "name": "video-720",
           "width": 1280,
           "height": 720,


### PR DESCRIPTION
Removed the 'Parent namespace' field from the clone track object and updated relevant sections.

This PR undoes an accidental commit directly to main of a feature change. 